### PR TITLE
fixed issue where NullPointerException in MessageView

### DIFF
--- a/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/views/MessageView.java
+++ b/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/views/MessageView.java
@@ -135,7 +135,8 @@ public class MessageView extends ListView implements View.OnFocusChangeListener{
         super.onSizeChanged(width, height, oldWidth, oldHeight);
 
         // if ListView became smaller
-        if (height < oldHeight) {
+        if (mOnKeyboardAppearListener != null
+                && height < oldHeight) {
             mOnKeyboardAppearListener.onKeyboardAppeared(true);
         }
     }


### PR DESCRIPTION
bassaerさん


こちらはmOnKeyboardAppearListenerを利用しない場合、ViewのonSizeChanged が走ったタイミングでNullPointerExceptionが発生してしまうためnullチェックを入れています。
ご確認よろしくお願いいたします。