### PR TITLE
MessageView (+example) crash fix

### DIFF
--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
@@ -172,7 +172,7 @@ class MessageView : ListView, View.OnFocusChangeListener {
         super.onSizeChanged(width, height, oldWidth, oldHeight)
 
         // if ListView became smaller
-        if (keyboardAppearListener != null && height < oldHeight) {
+        if (::keyboardAppearListener.isInitialized && height < oldHeight) {
             keyboardAppearListener.onKeyboardAppeared(true)
         }
     }

--- a/example/src/main/java/com/github/bassaer/example/SimpleChatActivity.java
+++ b/example/src/main/java/com/github/bassaer/example/SimpleChatActivity.java
@@ -53,7 +53,7 @@ public class SimpleChatActivity extends Activity {
             messages.add(message2);
         }
 
-        MessageView messageView = (MessageView)findViewById(R.id.messageView);
+        MessageView messageView = findViewById(R.id.message_view);
         messageView.init(messages);
 
     }


### PR DESCRIPTION
There was a critial bug in ChatView: (lateinit property != null) causes exception