### PR TITLE
Add support for chat activity messages

### DIFF
--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/Attribute.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/Attribute.kt
@@ -15,9 +15,11 @@ class Attribute(context: Context, attrs: AttributeSet?) {
     var messageMaxWidth: Int
     var dateSeparatorFontSize: Float
     var isOptionButtonEnable: Boolean
+    var chatActivityMessageFontSize: Float
 
     init {
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.MessageView)
+
         this.messageFontSize = typedArray.getDimension(
                 R.styleable.MessageView_message_font_size,
                 context.resources.getDimension(R.dimen.font_normal)
@@ -42,6 +44,11 @@ class Attribute(context: Context, attrs: AttributeSet?) {
                 R.styleable.MessageView_option_button_enable,
                 false
         )
+
+        this.chatActivityMessageFontSize = typedArray.getDimension(R.styleable.MessageView_chat_activity_message_font_size,
+                context.resources.getDimension(R.dimen.font_small)
+        )
+
         typedArray.recycle()
     }
 }

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/ChatActivityMessage.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/ChatActivityMessage.kt
@@ -1,0 +1,30 @@
+package com.github.bassaer.chatmessageview.model
+
+/**
+ * Created by marcos-ambrosi on 2/13/18.
+ */
+class ChatActivityMessage {
+
+
+    /**
+     * Message to be shown as part of the chat's activity.
+     */
+    var message = ""
+
+    /**
+     * ChatActivityMessage builder
+     */
+    class Builder {
+
+        private val chatActivityMessage: ChatActivityMessage = ChatActivityMessage()
+
+        fun setMessage(message: String): Builder {
+            chatActivityMessage.message = message
+            return this
+        }
+
+        fun build(): ChatActivityMessage {
+            return chatActivityMessage
+        }
+    }
+}

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/ChatActivityMessage.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/ChatActivityMessage.kt
@@ -1,10 +1,11 @@
 package com.github.bassaer.chatmessageview.model
 
+import java.util.*
+
 /**
  * Created by marcos-ambrosi on 2/13/18.
  */
-class ChatActivityMessage {
-
+class ChatActivityMessage : SortableMessage() {
 
     /**
      * Message to be shown as part of the chat's activity.
@@ -20,6 +21,11 @@ class ChatActivityMessage {
 
         fun setMessage(message: String): Builder {
             chatActivityMessage.message = message
+            return this
+        }
+
+        fun setCreatedAt(calendar: Calendar): Builder {
+            chatActivityMessage.createdAt = calendar
             return this
         }
 

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/Message.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/Message.kt
@@ -9,7 +9,7 @@ import java.util.*
  * Message object
  * Created by nakayama on 2016/08/08.
  */
-class Message {
+class Message : SortableMessage() {
 
     /**
      * Sender information
@@ -41,11 +41,6 @@ class Message {
     var messageText: String? = null
 
     /**
-     * The time message that was created
-     */
-    var createdAt = Calendar.getInstance()
-
-    /**
      * Whether cell of list view is date separator text or not.
      */
     var isDateCell: Boolean = false
@@ -54,12 +49,6 @@ class Message {
      * TEXT format of the send time that is next to the message
      */
     private var mSendTimeFormatter: ITimeFormatter? = null
-
-    /**
-     * Date separator text format.
-     * This text is shown if the before or after message was sent different day
-     */
-    private var mDateFormatter: ITimeFormatter? = null
 
     /**
      * Message status
@@ -94,9 +83,6 @@ class Message {
 
     val timeText: String
         get() = mSendTimeFormatter!!.getFormattedTimeText(createdAt!!)
-
-    val dateSeparateText: String
-        get() = mDateFormatter!!.getFormattedTimeText(createdAt!!)
 
     val statusIcon: Drawable
         get() = statusIconFormatter!!.getStatusIcon(status, isRightMessage)

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/SortableMessage.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/model/SortableMessage.kt
@@ -1,0 +1,29 @@
+package com.github.bassaer.chatmessageview.model
+
+import com.github.bassaer.chatmessageview.util.ITimeFormatter
+import java.util.*
+
+/**
+ * Created by marcos-ambrosi on 2/21/18.
+ */
+abstract class SortableMessage {
+
+    /**
+     * Date separator text format.
+     * This text is shown if the before or after message was sent different day
+     */
+    var mDateFormatter: ITimeFormatter? = null
+
+
+    /**
+     * The time message that was created
+     */
+    var createdAt = Calendar.getInstance()
+
+    val dateSeparateText: String
+        get() = mDateFormatter!!.getFormattedTimeText(createdAt!!)
+
+    init {
+        createdAt = Calendar.getInstance()
+    }
+}

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/util/MessageDateComparator.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/util/MessageDateComparator.kt
@@ -1,10 +1,11 @@
 package com.github.bassaer.chatmessageview.util
 
 import com.github.bassaer.chatmessageview.model.Message
+import com.github.bassaer.chatmessageview.model.SortableMessage
 import java.util.*
 
-class MessageDateComparator : Comparator<Message> {
-    override fun compare(first: Message, second: Message): Int {
+class MessageDateComparator : Comparator<SortableMessage> {
+    override fun compare(first: SortableMessage, second: SortableMessage): Int {
         if (first.createdAt.before(second.createdAt)) {
             return -1
         }

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/ChatView.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/ChatView.kt
@@ -15,6 +15,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
 import android.widget.LinearLayout
 import com.github.bassaer.chatmessageview.R
+import com.github.bassaer.chatmessageview.model.ChatActivityMessage
 import com.github.bassaer.chatmessageview.model.Message
 import com.github.bassaer.chatmessageview.models.Attribute
 import kotlinx.android.synthetic.main.chat_view.view.*
@@ -132,6 +133,17 @@ class ChatView : LinearLayout {
         }
     }
 
+    /**
+     * Set message to be shown centered in the chat view.
+     * @param chatActivityMessage Message to be shown
+     */
+    fun showChatActivityMessage(chatActivityMessage: ChatActivityMessage) {
+        messageView.addChatActivityMessage(chatActivityMessage)
+        if (isEnableAutoScroll) {
+            messageView.scrollToEnd()
+        }
+    }
+
     fun setOnClickSendButtonListener(listener: View.OnClickListener) {
         sendButton.setOnClickListener(listener)
     }
@@ -168,8 +180,8 @@ class ChatView : LinearLayout {
     }
 
     fun setOptionButtonColor(color: Int) {
-            optionIconColor = color
-            optionButton.setImageDrawable(getColoredDrawable(color, optionIconId))
+        optionIconColor = color
+        optionButton.setImageDrawable(getColoredDrawable(color, optionIconId))
     }
 
     private fun getColoredDrawable(color: Int, iconId: Int): Drawable {

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/ChatView.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/ChatView.kt
@@ -138,7 +138,7 @@ class ChatView : LinearLayout {
      * @param chatActivityMessage Message to be shown
      */
     fun showChatActivityMessage(chatActivityMessage: ChatActivityMessage) {
-        messageView.addChatActivityMessage(chatActivityMessage)
+        messageView.setChatActivityMessage(chatActivityMessage)
         if (isEnableAutoScroll) {
             messageView.scrollToEnd()
         }

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageAdapter.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageAdapter.kt
@@ -16,6 +16,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
 import com.github.bassaer.chatmessageview.R
+import com.github.bassaer.chatmessageview.model.ChatActivityMessage
 import com.github.bassaer.chatmessageview.model.Message
 import com.github.bassaer.chatmessageview.models.Attribute
 import de.hdodenhof.circleimageview.CircleImageView
@@ -56,6 +57,7 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
     init {
         viewTypes.add(String::class.java)
         viewTypes.add(Message::class.java)
+        viewTypes.add(ChatActivityMessage::class.java)
         leftBubbleColor = ContextCompat.getColor(context, R.color.default_left_bubble_color)
         rightBubbleColor = ContextCompat.getColor(context, R.color.default_right_bubble_color)
     }
@@ -89,6 +91,24 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
             dateViewHolder.dateLabelText?.text = item
             dateViewHolder.dateLabelText?.setTextColor(dateLabelColor)
             dateViewHolder.dateLabelText?.setTextSize(TypedValue.COMPLEX_UNIT_PX, attribute.dateSeparatorFontSize)
+
+        } else if (item is ChatActivityMessage) {
+
+            lateinit var chatActivityMessageViewHolder: ChatActivityMessageViewHolder
+            val chatActivityMessage: ChatActivityMessage = item
+
+            view?.let {
+                chatActivityMessageViewHolder = it.tag as ChatActivityMessageViewHolder
+            } ?: let {
+                view = layoutInflater.inflate(R.layout.chat_activity_message_cell, null)
+                chatActivityMessageViewHolder = ChatActivityMessageViewHolder()
+                chatActivityMessageViewHolder.activityMessageLabelText = view?.findViewById(R.id.activityMessageLabelText)
+                view?.tag = chatActivityMessageViewHolder
+            }
+
+            chatActivityMessageViewHolder.activityMessageLabelText?.text = chatActivityMessage.message
+            chatActivityMessageViewHolder.activityMessageLabelText?.setTextColor(dateLabelColor)
+            chatActivityMessageViewHolder.activityMessageLabelText?.setTextSize(TypedValue.COMPLEX_UNIT_PX, attribute.dateSeparatorFontSize)
 
         } else {
             //Item is a message
@@ -207,7 +227,8 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
                         )
                     }
 
-                } else -> {
+                }
+                else -> {
                     layoutInflater.inflate(
                             if (message.isRightMessage) R.layout.message_text_right else R.layout.message_text_left,
                             messageViewHolder.mainMessageContainer).let {
@@ -372,6 +393,10 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
 
     internal inner class DateViewHolder {
         var dateLabelText: TextView? = null
+    }
+
+    internal inner class ChatActivityMessageViewHolder {
+        var activityMessageLabelText: TextView? = null
     }
 
 

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageAdapter.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageAdapter.kt
@@ -40,6 +40,7 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
     private var usernameTextColor = ContextCompat.getColor(getContext(), R.color.blueGray500)
     private var sendTimeTextColor = ContextCompat.getColor(getContext(), R.color.blueGray500)
     private var dateLabelColor = ContextCompat.getColor(getContext(), R.color.blueGray500)
+    private var activityMessageTextColor = ContextCompat.getColor(getContext(), R.color.blueGray500)
     private var rightMessageTextColor = Color.WHITE
     private var leftMessageTextColor = Color.BLACK
     private var leftBubbleColor: Int = 0
@@ -107,8 +108,8 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
             }
 
             chatActivityMessageViewHolder.activityMessageLabelText?.text = chatActivityMessage.message
-            chatActivityMessageViewHolder.activityMessageLabelText?.setTextColor(dateLabelColor)
-            chatActivityMessageViewHolder.activityMessageLabelText?.setTextSize(TypedValue.COMPLEX_UNIT_PX, attribute.dateSeparatorFontSize)
+            chatActivityMessageViewHolder.activityMessageLabelText?.setTextColor(activityMessageTextColor)
+            chatActivityMessageViewHolder.activityMessageLabelText?.setTextSize(TypedValue.COMPLEX_UNIT_PX, attribute.chatActivityMessageFontSize)
 
         } else {
             //Item is a message
@@ -344,6 +345,11 @@ class MessageAdapter(context: Context, resource: Int, private val objects: List<
 
     fun setDateSeparatorColor(dateSeparatorColor: Int) {
         this.dateLabelColor = dateSeparatorColor
+        notifyDataSetChanged()
+    }
+
+    fun setActivityMessageColor(activityMessageColor: Int) {
+        this.activityMessageTextColor = activityMessageColor
         notifyDataSetChanged()
     }
 

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.ListView
 import com.github.bassaer.chatmessageview.model.ChatActivityMessage
 import com.github.bassaer.chatmessageview.model.Message
+import com.github.bassaer.chatmessageview.model.SortableMessage
 import com.github.bassaer.chatmessageview.models.Attribute
 import com.github.bassaer.chatmessageview.util.MessageDateComparator
 import com.github.bassaer.chatmessageview.util.TimeUtils
@@ -26,7 +27,7 @@ class MessageView : ListView, View.OnFocusChangeListener {
     /**
      * Only messages
      */
-    val messageList = ArrayList<Message>()
+    val messageList = ArrayList<SortableMessage>()
 
     private lateinit var messageAdapter: MessageAdapter
 
@@ -101,9 +102,9 @@ class MessageView : ListView, View.OnFocusChangeListener {
     /**
      * Add message to chat list and message list.
      * Set date text before set message if sent at the different day.
-     * @param message new message
+     * @param SortableMessage new message
      */
-    private fun addMessage(message: Message) {
+    private fun addMessage(message: SortableMessage) {
         messageList.add(message)
         if (messageList.size == 1) {
             chatList.add(message.dateSeparateText)
@@ -134,7 +135,7 @@ class MessageView : ListView, View.OnFocusChangeListener {
         refresh()
     }
 
-    private fun insertDateSeparator(list: List<Message>): List<Any> {
+    private fun insertDateSeparator(list: List<SortableMessage>): List<Any> {
         val result = ArrayList<Any>()
         if (list.isEmpty()) {
             return result
@@ -158,7 +159,7 @@ class MessageView : ListView, View.OnFocusChangeListener {
     /**
      * Sort messages
      */
-    private fun sortMessages(list: List<Message>?) {
+    private fun sortMessages(list: List<SortableMessage>?) {
         val dateComparator = MessageDateComparator()
         if (list != null) {
             Collections.sort(list, dateComparator)
@@ -168,8 +169,9 @@ class MessageView : ListView, View.OnFocusChangeListener {
     /**
      * Adds an activity message. E.g: "John has joined the chat"
      */
-    fun addChatActivityMessage(activityMessage: ChatActivityMessage) {
-        chatList.add(activityMessage)
+    fun setChatActivityMessage(activityMessage: ChatActivityMessage) {
+        addMessage(activityMessage)
+        refresh()
         messageAdapter.notifyDataSetChanged()
     }
 

--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.util.AttributeSet
 import android.view.View
 import android.widget.ListView
+import com.github.bassaer.chatmessageview.model.ChatActivityMessage
 import com.github.bassaer.chatmessageview.model.Message
 import com.github.bassaer.chatmessageview.models.Attribute
 import com.github.bassaer.chatmessageview.util.MessageDateComparator
@@ -162,6 +163,14 @@ class MessageView : ListView, View.OnFocusChangeListener {
         if (list != null) {
             Collections.sort(list, dateComparator)
         }
+    }
+
+    /**
+     * Adds an activity message. E.g: "John has joined the chat"
+     */
+    fun addChatActivityMessage(activityMessage: ChatActivityMessage) {
+        chatList.add(activityMessage)
+        messageAdapter.notifyDataSetChanged()
     }
 
     fun setOnKeyboardAppearListener(listener: OnKeyboardAppearListener) {

--- a/chatmessageview/src/main/res/layout/chat_activity_message_cell.xml
+++ b/chatmessageview/src/main/res/layout/chat_activity_message_cell.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/activityMessageLabelText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:gravity="center"
+        android:textSize="@dimen/font_small" />
+
+</LinearLayout>

--- a/chatmessageview/src/main/res/values/attrs.xml
+++ b/chatmessageview/src/main/res/values/attrs.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="MessageView">
-        <attr name="message_font_size" format="dimension"/>
-        <attr name="username_font_size" format="dimension"/>
-        <attr name="time_label_font_size" format="dimension"/>
-        <attr name="message_max_width" format="dimension"/>
-        <attr name="date_separator_font_size" format="dimension"/>
-        <attr name="option_button_enable" format="boolean"/>
+        <attr name="message_font_size" format="dimension" />
+        <attr name="username_font_size" format="dimension" />
+        <attr name="time_label_font_size" format="dimension" />
+        <attr name="message_max_width" format="dimension" />
+        <attr name="date_separator_font_size" format="dimension" />
+        <attr name="option_button_enable" format="boolean" />
+        <attr name="chat_activity_message_font_size" format="dimension" />
     </declare-styleable>
 </resources>

--- a/example/src/main/java/com/github/bassaer/example/MessageList.java
+++ b/example/src/main/java/com/github/bassaer/example/MessageList.java
@@ -3,9 +3,12 @@ package com.github.bassaer.example;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Base64;
+import android.util.Log;
 
+import com.github.bassaer.chatmessageview.model.ChatActivityMessage;
 import com.github.bassaer.chatmessageview.model.Message;
 import com.github.bassaer.chatmessageview.model.IChatUser;
+import com.github.bassaer.chatmessageview.model.SortableMessage;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -32,8 +35,8 @@ public class MessageList {
         return messages;
     }
 
-    public void setMessages(List<Message> messages) {
-        for (Message message : messages) {
+    public void setMessages(List<SortableMessage> messages) {
+        for (SortableMessage message : messages) {
             mMessages.add(convertMessage(message));
         }
     }
@@ -58,24 +61,34 @@ public class MessageList {
         return mMessages.size();
     }
 
-    private SaveMessage convertMessage(Message message) {
-        SaveMessage saveMessage = new SaveMessage(
-                Integer.valueOf(message.getUser().getId()),
-                message.getUser().getName(),
-                message.getMessageText(),
-                message.getCreatedAt(),
-                message.isRightMessage());
+    private SaveMessage convertMessage(SortableMessage sortableMessage) {
 
-        saveMessage.setType(message.getType());
+        if (sortableMessage instanceof ChatActivityMessage) {
+            return new SaveMessage(sortableMessage.getCreatedAt());
+        } else if (sortableMessage instanceof Message) {
 
-        if (message.getType() == Message.Type.PICTURE
-                && message.getPicture() != null) {
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            message.getPicture().compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
-            saveMessage.setPictureString(Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT));
+            Message message = (Message) sortableMessage;
+
+            SaveMessage saveMessage = new SaveMessage(
+                    Integer.valueOf(message.getUser().getId()),
+                    message.getUser().getName(),
+                    message.getMessageText(),
+                    message.getCreatedAt(),
+                    message.isRightMessage());
+
+            saveMessage.setType(message.getType());
+
+            if (message.getType() == Message.Type.PICTURE
+                    && message.getPicture() != null) {
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                message.getPicture().compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
+                saveMessage.setPictureString(Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT));
+            }
+
+            return saveMessage;
         }
 
-        return saveMessage;
+        return null;
     }
 
     private Message convertMessage(SaveMessage saveMessage) {
@@ -111,6 +124,14 @@ public class MessageList {
             mContent = content;
             mCreatedAt = createdAt;
             mRightMessage = isRightMessage;
+        }
+
+        public SaveMessage(Calendar createdAt) {
+            mId = Integer.MIN_VALUE;
+            mUsername = "";
+            mContent = "";
+            mCreatedAt = createdAt;
+            mRightMessage = false;
         }
 
         public int getId() {

--- a/example/src/main/java/com/github/bassaer/example/SimpleChatActivity.java
+++ b/example/src/main/java/com/github/bassaer/example/SimpleChatActivity.java
@@ -59,7 +59,7 @@ public class SimpleChatActivity extends Activity {
 
 
         ChatActivityMessage activityMessage = new ChatActivityMessage.Builder().setMessage("Michael has left the chat").build();
-        messageView.addChatActivityMessage(activityMessage);
+        messageView.setChatActivityMessage(activityMessage);
 
     }
 }

--- a/example/src/main/java/com/github/bassaer/example/SimpleChatActivity.java
+++ b/example/src/main/java/com/github/bassaer/example/SimpleChatActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 
+import com.github.bassaer.chatmessageview.model.ChatActivityMessage;
 import com.github.bassaer.chatmessageview.model.Message;
 import com.github.bassaer.chatmessageview.view.MessageView;
 
@@ -55,6 +56,10 @@ public class SimpleChatActivity extends Activity {
 
         MessageView messageView = findViewById(R.id.message_view);
         messageView.init(messages);
+
+
+        ChatActivityMessage activityMessage = new ChatActivityMessage.Builder().setMessage("Michael has left the chat").build();
+        messageView.addChatActivityMessage(activityMessage);
 
     }
 }


### PR DESCRIPTION
This feature might be useful (in group chats mostly) for:
* Whenever a user joins/leaves a group chat.
* A user changes his name.
* A chat name is changed.

![device-2018-02-19-184330](https://user-images.githubusercontent.com/2334119/36398434-e5931cfc-15a5-11e8-8736-1d1bd40193a3.png)
