### PR TITLE
Memory leak prevention issue #82

### DIFF
--- a/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
+++ b/chatmessageview/src/main/kotlin/com/github/bassaer/chatmessageview/view/MessageView.kt
@@ -9,6 +9,7 @@ import com.github.bassaer.chatmessageview.model.Message
 import com.github.bassaer.chatmessageview.models.Attribute
 import com.github.bassaer.chatmessageview.util.MessageDateComparator
 import com.github.bassaer.chatmessageview.util.TimeUtils
+import java.lang.ref.WeakReference
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -78,11 +79,12 @@ class MessageView : ListView, View.OnFocusChangeListener {
 
         adapter = messageAdapter
 
+        val weakMessageAdapter: WeakReference<MessageAdapter> = WeakReference(messageAdapter)
         val handler = Handler()
         val refreshTimer = Timer(true)
         refreshTimer.schedule(object : TimerTask() {
             override fun run() {
-                handler.post { messageAdapter.notifyDataSetChanged() }
+                handler.post { weakMessageAdapter.get()?.notifyDataSetChanged() }
             }
         }, 1000, refreshInterval)
     }


### PR DESCRIPTION
Thank you for a great library

I have taken measures against issue #82.
It seems that anonymous inner classes were not covered by GC because they kept references to outer classes.
MessageAdapter changed from strong reference to weak reference.

I performed an operation check and confirmed that memory leak does not occur in LeakCanary.